### PR TITLE
Temporal entropy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalReliabilityScores"
 uuid = "7f59ec08-e101-11e9-23f0-33f1ad6c80eb"
 authors = ["Roger Herikstad <roger.herikstad@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,5 +4,6 @@ authors = ["Roger Herikstad <roger.herikstad@gmail.com>"]
 version = "0.3.0"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using TemporalReliabilityScores
+using Random
 const TSR = TemporalReliabilityScores
 using Test
 
@@ -35,4 +36,16 @@ end
 	@test eer[3] ≈ 1.021651247531981
 	@test ee[4] ≈ 1.5444795210968603
 	@test eer[4] ≈ 1.491654876777717
+end
+
+@testset "Temporal entropy score" begin
+	idx1 = fill(3,20)
+	idx2 = [3, 3, 3, 4, 4, 3, 3, 3, 3, 3, 3, 4, 4, 3, 4, 3, 4, 3, 3, 3]
+	X = falses(5,20)
+	for (ii, _idx) in enumerate(idx2)
+		X[_idx,ii] = true
+	end
+	ee1,ee0 = TSR.tr_entropy_score(X, 2.0;RNG=MersenneTwister(1234))
+	@test ee1 ≈ 0.5447271754416722
+	@test ee0 ≈ 1.436004650013498
 end


### PR DESCRIPTION
Adds code to compute a shuffle-corrected  temporal reliability score.